### PR TITLE
refactor: Update SuccessViewB to redirect to new member page

### DIFF
--- a/src/app/(signup-funnel)/(signup-funnel-b)/gmail-link_b/success/_components/SuccessViewB.tsx
+++ b/src/app/(signup-funnel)/(signup-funnel-b)/gmail-link_b/success/_components/SuccessViewB.tsx
@@ -85,7 +85,8 @@ export function SuccessViewB() {
                 position: 'bottom-center'
             });
 
-            router.push('/user-rps');
+            // router.push('/user-rps'); // TODO: Uncomment this when we have the new member page
+            router.push('/new-member');
         } catch (error) {
             console.error('Form submission error:', error);
             toast.error(error instanceof Error ? error.message : 'Something went wrong', {


### PR DESCRIPTION
This commit modifies the SuccessViewB component to change the redirection path from '/user-rps' to '/new-member'. A commented-out line indicates the previous route, with a note to uncomment it when the new member page is ready. This change aims to streamline user navigation following successful actions in the signup funnel.