### PR TITLE
refactor: Restore redirection logic in PhoneRegisterView component

### DIFF
--- a/src/app/auth/_components/PhoneRegisterView.tsx
+++ b/src/app/auth/_components/PhoneRegisterView.tsx
@@ -161,16 +161,14 @@ export function PhoneRegisterView({ redirectUrl, state_id }: PhoneRegisterViewPr
             }
 
             if (data.success) {
-                console.log('TOKEN', data.token);
-                console.log('CUSTOMER ID', data.customer_id);
                 login(data.token, data.customer_id);
 
                 toast.success('Login successful');
-                // if (redirectUrl) {
-                //     router.push(redirectUrl);
-                // } else {
-                //     router.push('/user-rps');
-                // }
+                if (redirectUrl) {
+                    router.push(redirectUrl);
+                } else {
+                    router.push('/user-rps');
+                }
             } else {
                 throw new Error(data.message || 'Verification failed');
             }


### PR DESCRIPTION
This commit reinstates the redirection logic in the PhoneRegisterView component, allowing users to navigate to a specified redirect URL or defaulting to '/user-rps' upon successful login. The previous commented-out code has been activated to enhance user navigation following authentication.