### PR TITLE
feat: Update redirection for fake trips in UserRpFlight and Hotel Con…

### DIFF
--- a/src/app/(hotel-rp-pages)/user-rp/[rp-id]/_components/UserRpConfirmRepricingView/UserRpFlightConfirmationSection.tsx
+++ b/src/app/(hotel-rp-pages)/user-rp/[rp-id]/_components/UserRpConfirmRepricingView/UserRpFlightConfirmationSection.tsx
@@ -57,7 +57,7 @@ export default function UserRpFlightConfirmationSection({ trip }: UserRpFlightCo
         setIsSubmitting(true);
 
         if (trip.is_fake) {
-            router.push(`/rp-success/${trip.id}`);
+            router.push(`/rp-success/${trip.import_session_id}`);
 
             return;
         }

--- a/src/app/(hotel-rp-pages)/user-rp/[rp-id]/_components/UserRpConfirmRepricingView/UserRpHotelConfirmationSection.tsx
+++ b/src/app/(hotel-rp-pages)/user-rp/[rp-id]/_components/UserRpConfirmRepricingView/UserRpHotelConfirmationSection.tsx
@@ -26,7 +26,7 @@ export default function UserRpHotelConfirmationSection({ trip }: UserRpHotelConf
         setIsSubmitting(true);
 
         if (trip.is_fake) {
-            router.push(`/rp-success/${trip.id}`);
+            router.push(`/rp-success/${trip.import_session_id}`);
 
             return;
         }


### PR DESCRIPTION
…firmation Sections

This commit modifies the redirection logic for fake trips in both UserRpFlightConfirmationSection and UserRpHotelConfirmationSection components. The user is now redirected to the success page using the trip's import_session_id instead of the trip's id, ensuring consistency in the redirection process.