### PR TITLE
grab referral_code query param, save local storage, send to be when c…

### DIFF
--- a/src/app/(top-funnel)/welcome/_components/DesktopLeftContentSteps/DesktopLeftContentMembership.tsx
+++ b/src/app/(top-funnel)/welcome/_components/DesktopLeftContentSteps/DesktopLeftContentMembership.tsx
@@ -28,11 +28,21 @@ export default function DesktopLeftContentMembership() {
                 return;
             }
 
+            // fetch referral code from local storage if present and clear it + send to BE stripe link builder api
+            const referral_code = localStorage.getItem('referral_code');
+            if (referral_code) {
+                localStorage.removeItem('referral_code');
+            }
+            const stripe_signup_request_body = {
+                state_id,
+                ...(referral_code ? { referral_code } : {})
+            };
+
             try {
                 const response = await fetch('/api/stripe-signup', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ state_id })
+                    body: JSON.stringify(stripe_signup_request_body)
                 });
 
                 const data = await response.json();

--- a/src/app/(top-funnel)/welcome/_components/DesktopLeftContentSteps/DesktopLeftContentWelcome.tsx
+++ b/src/app/(top-funnel)/welcome/_components/DesktopLeftContentSteps/DesktopLeftContentWelcome.tsx
@@ -71,6 +71,11 @@ export default function DesktopLeftContentWelcome() {
                 const fbp = Cookies.get('_fbp');
                 const fbc = Cookies.get('_fbc');
 
+                const referral_code = searchParams.get('referral_code');
+                if (referral_code) {
+                    localStorage.setItem('referral_code', referral_code);
+                }
+
                 const utmParams = getUtmParams();
                 const response = await fetch('/api/gmail/state', {
                     method: 'POST',

--- a/src/app/(top-funnel)/welcome/_components/MobileContentSteps/MobileContentMembership.tsx
+++ b/src/app/(top-funnel)/welcome/_components/MobileContentSteps/MobileContentMembership.tsx
@@ -61,11 +61,21 @@ export default function MobileContentMembership() {
                 return;
             }
 
+            // fetch referral code from local storage if present and clear it + send to BE stripe link builder api
+            const referral_code = localStorage.getItem('referral_code');
+            if (referral_code) {
+                localStorage.removeItem('referral_code');
+            }
+            const stripe_signup_request_body = {
+                state_id,
+                ...(referral_code ? { referral_code } : {})
+            };
+
             try {
                 const response = await fetch('/api/stripe-signup', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ state_id })
+                    body: JSON.stringify(stripe_signup_request_body)
                 });
 
                 const data = await response.json();

--- a/src/app/(top-funnel)/welcome/_components/MobileWelcomeView.tsx
+++ b/src/app/(top-funnel)/welcome/_components/MobileWelcomeView.tsx
@@ -62,6 +62,12 @@ const MobileSheetStep0Content = ({ onNext }: { onNext?: (stateId: string) => voi
         try {
             const fbp = Cookies.get('_fbp');
             const fbc = Cookies.get('_fbc');
+
+            const referral_code = searchParams.get('referral_code');
+            if (referral_code) {
+                localStorage.setItem('referral_code', referral_code);
+            }
+
             const utmParams = getUtmParams();
 
             const response = await fetch('/api/gmail/state', {


### PR DESCRIPTION
## Summary
Customers reaching out about referral program.

We will create them a link like: `https://app.heyascend.com/welcome?referral_code=AXBY`

On front-end for both DESKTOP and MOBILE:
1. Check if that query param is available on page load and save to localStorage
2. When user gets to step 3, FE will fetch referral_code from localStorage and send it to stripe signup link url in BE. Also remove that item from localStorage after

## TESTING
I did:
```
npm install 

npm run dev
```

opened: `http://localhost:3003/welcome` and added console.logs to see if we were saving referral_code by creating this url: `http://localhost:3003/welcome?referral_code=ABCDE`

Then for stripe link fetching, used this local url: `http://localhost:3003/welcome?step=3&state_id=abc123` to check my console.logs and make sure we can fetch referral_code if present and add to request to `/api/stripe-signup` which calls BE api